### PR TITLE
fix: articles API 수정사항에 맞추어 게시물 로딩 수정

### DIFF
--- a/features/home/Section1.tsx
+++ b/features/home/Section1.tsx
@@ -80,7 +80,7 @@ export default function HomeSection1() {
       )}
       {posts.length === 0 && !isLoading && <HomePost post={getFirstPage()} />}
       <div className="flex flex-col gap-7">
-        {posts?.map((post) => {
+        {posts?.filter((post) => post.bookTitle == false).map((post) => {
           return <HomePost key={post.id} post={post} />;
         })}
       </div>

--- a/features/home/Section2.tsx
+++ b/features/home/Section2.tsx
@@ -86,7 +86,7 @@ export default function HomeSection2() {
         </div>
       )}
       <div className="flex flex-col gap-7">
-        {posts?.map((post) => {
+        {posts?.filter((post) => post.bookTitle == false).map((post) => {
           return <HomePost key={post.id} post={post} />;
         })}
       </div>

--- a/features/post/firstPost.ts
+++ b/features/post/firstPost.ts
@@ -61,5 +61,6 @@ export function getFirstPage(): PostRes {
     createdAt: "", // 계정 생성 시각
     updatedAt: "",
     cheerings: [],
+    bookTitle: false,
   };
 }

--- a/features/user/Posts.tsx
+++ b/features/user/Posts.tsx
@@ -131,7 +131,7 @@ export default function Posts({ userId }: { userId: string }) {
         </div>
       )}
       <div ref={containerRef} className="grid grid-cols-3 gap-[1px]">
-        {posts?.map((post) => {
+        {posts?.filter((post) => post.bookTitle == false).map((post) => {
           return (
             <Link key={post.id} href={`/post/${post.id}`} scroll={false}>
               <TitlePage size={size} post={post} />

--- a/types/Post.ts
+++ b/types/Post.ts
@@ -47,6 +47,7 @@ export type PostRes = {
   createdAt: string; // ISO 8601 datetime string
   updatedAt: string; // ISO 8601 datetime string
   cheerings?: Cheering[];
+  bookTitle: boolean;
 };
 
 export type Question = {


### PR DESCRIPTION
- 변경사항:

    책 관련 기능 추가로 백엔드 응답에 bookTitle 속성이 추가된 것을 반영하여 PostRes 타입을 수정했습니다.
    책 정보를 담는 용도의 게시물이 게시물 목록에 같이 불러와져 오류를 일으키는 문제를 해결했습니다.


혹시 게시물 목록을 API로 불러와서 화면에 띄우는 부분, PostRes 타입의 데이터를 생성하는 부분이 더 있다면 알려주시면 감사하겠습니다.