### PR TITLE
fix: 프로필 이미지 안 뜨는 문제 수정

### DIFF
--- a/features/auth/OathForm.tsx
+++ b/features/auth/OathForm.tsx
@@ -2,7 +2,6 @@ import { NextStepButton } from "./Buttons";
 import { useSignupInfoStore } from "@/store/SignupStore";
 import { format } from "date-fns";
 import { useState } from "react";
-import { defaultProfileImg } from "../user/defaultProfileImg";
 import Post from "../post/Post";
 
 export default function OathForm() {
@@ -51,7 +50,7 @@ export default function OathForm() {
   async function handleSignUp() {
     setIsLoading(true);
     const payload = {
-      profileImageUrl: defaultProfileImg,
+      profileImageUrl: null,
       birth: format(user.birth!, "yyyy-MM-dd"),
       categories: user.categories,
     };

--- a/features/user/defaultProfileImg.ts
+++ b/features/user/defaultProfileImg.ts
@@ -1,2 +1,2 @@
 export const defaultProfileImg =
-  "https://achivadata.s3.ap-northeast-2.amazonaws.com/3bada948-2a04-4748-b042-916e84d8da50";
+  "https://achivadata.s3.ap-northeast-2.amazonaws.com/default-profile-image.png";


### PR DESCRIPTION
회원가입 시 기본 프로필 + Achiva 공식 계정(인 척 하는 더미 게시글) 프로필 안 보이는 문제 수정
원래 회원가입 과정에서 닉네임 입력받는 거 반영하면서 같이 수정하려고 했는데 일단 시연을 위해 미리 수정