### PR TITLE
Codex/today grace editor polish

### DIFF
--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -10,17 +10,21 @@ type Props = {
   children: React.ReactNode;
   onClick?: () => void | undefined;
   rightElement?: React.ReactNode;
+  className?: string;
 };
 
 export default function MobileHeader({
   children,
   onClick = undefined,
   rightElement,
+  className = "",
 }: Props) {
   const router = useRouter();
 
   return (
-    <div className="relative bg-white w-full h-14 mb-5 flex items-center justify-center border-b border-b-[#cccccc] z-50">
+    <div
+      className={`relative bg-white w-full h-14 mb-5 flex items-center justify-center border-b border-b-[#cccccc] z-50 ${className}`}
+    >
       <div
         className="absolute top left-4 scale-80 hover:cursor-pointer"
         onClick={onClick ?? router.back}

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -10,12 +10,14 @@ type ModalProps = {
   title?: React.ReactNode;
   children: React.ReactNode;
   onClose?: (() => void) | undefined;
+  className?: string;
 };
 
 export default function Modal({
   title = null,
   children,
   onClose = undefined,
+  className = "",
 }: ModalProps) {
   useEffect(() => {
     // 현재 스크롤바 너비 계산
@@ -49,7 +51,7 @@ export default function Modal({
           damping: 15,
           mass: 0.8,
         }}
-        className="relative rounded-lg bg-white p-8 flex flex-col max-h-[90dvh]"
+        className={`relative rounded-lg bg-white p-8 flex flex-col max-h-[90dvh] ${className}`}
       >
         <div className="flex items-center justify-center relative w-full">
           <div className="font-bold text-xl w-full">{title}</div>

--- a/features/home/MyCategorys.tsx
+++ b/features/home/MyCategorys.tsx
@@ -7,7 +7,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Category } from "@/types/Categories";
-import { createDefaultPostPages } from "@/lib/postDefaults";
+import {
+  createDefaultPostPages,
+  getDefaultPostBackground,
+} from "@/lib/postDefaults";
 import { buildMobileUserPath, buildUserPath } from "@/lib/nickname";
 
 export function MyCategorys({
@@ -66,6 +69,7 @@ export function MyCategorys({
     setPost({
       category: selectedCategory,
       categoryCount: cat.count,
+      backgroundColor: getDefaultPostBackground(selectedCategory),
       title: "",
       pages: createDefaultPostPages(selectedCategory),
     });

--- a/features/post/Pages.tsx
+++ b/features/post/Pages.tsx
@@ -3,6 +3,15 @@ import type { Question } from "@/types/Post";
 import PostImg from "@/components/PostImg";
 import { format } from "date-fns";
 import { getPostPageSurface, getPostPageTone } from "@/lib/postPageTheme";
+import PaperTitleCover from "./PaperTitleCover";
+import {
+  CONTENT_CARD_BODY_CLASS,
+  CONTENT_CARD_BODY_WRAP_CLASS,
+  CONTENT_CARD_DIVIDER_CLASS,
+  CONTENT_CARD_SHELL_CLASS,
+  CONTENT_CARD_TITLE_CLASS,
+  CONTENT_CARD_TITLE_WRAP_CLASS,
+} from "./contentCardLayout";
 
 type Props = {
   size: number;
@@ -13,6 +22,7 @@ export function TitlePage({ size, post }: Props) {
   const date = new Date(post.createdAt);
   const weeklyCount = post.weeklyWorkoutCount ?? null;
   const streakWeeks = post.continuousGoalWeeks ?? null;
+  const hasPhoto = Boolean(post.photoUrls?.[0]);
 
   return (
     <div style={{ height: size, width: size }}>
@@ -23,119 +33,138 @@ export function TitlePage({ size, post }: Props) {
         }}
         className="aspect-square w-[390px] h-[390px] relative overflow-hidden"
       >
-        <PostImg url={post.photoUrls?.[0] || null} filtered />
+        {hasPhoto ? (
+          <>
+            <PostImg url={post.photoUrls?.[0] || null} filtered />
 
-        {/* 그라디언트 오버레이 */}
-        <div
-          className="absolute inset-0"
-          style={{
-            background:
-              "linear-gradient(to bottom, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0) 35%, rgba(0,0,0,0.18) 65%, rgba(0,0,0,0.45) 100%)",
-          }}
-        />
+            <div
+              className="absolute inset-0"
+              style={{
+                background:
+                  "linear-gradient(to bottom, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0) 35%, rgba(0,0,0,0.18) 65%, rgba(0,0,0,0.45) 100%)",
+              }}
+            />
 
-        {/* 상단: 날짜 + 카테고리 태그 */}
-        <div className="absolute top-[22px] left-[22px] right-[22px] flex items-center justify-between">
-          <span
-            className="text-[13px] font-medium tracking-[0.12em] uppercase"
-            style={{ color: "rgba(255,255,255,0.75)" }}
-          >
-            {format(date, "yyyy · MM · dd")}
-          </span>
-          <span
-            className="text-[11px] font-semibold tracking-[0.08em] px-[10px] py-[4px] rounded-full border"
-            style={{
-              color: "rgba(255,255,255,0.85)",
-              borderColor: "rgba(255,255,255,0.3)",
-              background: "rgba(255,255,255,0.12)",
-              backdropFilter: "blur(6px)",
-            }}
-          >
-            {post.category}
-          </span>
-        </div>
-
-        {/* 상단 구분선 */}
-        <div
-          className="absolute left-[22px] right-[22px]"
-          style={{ top: "56px", height: "1px", background: "rgba(255,255,255,0.18)" }}
-        />
-
-        {/* 하단 콘텐츠 */}
-        <div className="absolute bottom-[22px] left-[22px] right-[22px]">
-          {/* 통계 배지 */}
-          {weeklyCount !== null && weeklyCount > 0 && (
-            <div className="flex items-center gap-[8px] mb-[14px] flex-wrap">
-              <div
-                className="flex items-center gap-[6px] px-[11px] py-[5px] rounded-full"
+            <div className="absolute top-[22px] left-[22px] right-[22px] flex items-center justify-between">
+              <span
+                className="text-[13px] font-medium tracking-[0.12em] uppercase"
+                style={{ color: "rgba(255,255,255,0.75)" }}
+              >
+                {format(date, "yyyy · MM · dd")}
+              </span>
+              <span
+                className="text-[11px] font-semibold tracking-[0.08em] px-[10px] py-[4px] rounded-full border"
                 style={{
-                  background: "rgba(255,255,255,0.15)",
-                  backdropFilter: "blur(10px)",
-                  border: "1px solid rgba(255,255,255,0.25)",
+                  color: "rgba(255,255,255,0.85)",
+                  borderColor: "rgba(255,255,255,0.3)",
+                  background: "rgba(255,255,255,0.12)",
+                  backdropFilter: "blur(6px)",
                 }}
               >
-                <span className="text-[13px] leading-none">
-                  {Array.from({ length: Math.min(weeklyCount, 7) }, (_, i) => (
-                    <span key={i}>🔥</span>
-                  ))}
-                </span>
-                <span
-                  className="text-[12px] font-semibold tracking-[0.03em]"
-                  style={{ color: "rgba(255,255,255,0.95)" }}
-                >
-                  이번 주 {weeklyCount}회
-                </span>
-              </div>
+                {post.category}
+              </span>
+            </div>
 
-              {streakWeeks !== null && streakWeeks >= 2 && (
-                <div
-                  className="flex items-center gap-[5px] px-[11px] py-[5px] rounded-full"
-                  style={{
-                    background:
-                      "linear-gradient(135deg, rgba(251,146,60,0.85) 0%, rgba(239,68,68,0.75) 100%)",
-                    backdropFilter: "blur(10px)",
-                    border: "1px solid rgba(255,200,100,0.35)",
-                  }}
-                >
-                  <span className="text-[13px] leading-none">⚡</span>
-                  <span
-                    className="text-[12px] font-bold tracking-[0.02em]"
-                    style={{ color: "rgba(255,255,255,1)" }}
+            <div
+              className="absolute left-[22px] right-[22px]"
+              style={{
+                top: "56px",
+                height: "1px",
+                background: "rgba(255,255,255,0.18)",
+              }}
+            />
+
+            <div className="absolute bottom-[22px] left-[22px] right-[22px]">
+              {weeklyCount !== null && weeklyCount > 0 && (
+                <div className="flex items-center gap-[8px] mb-[14px] flex-wrap">
+                  <div
+                    className="flex items-center gap-[6px] px-[11px] py-[5px] rounded-full"
+                    style={{
+                      background: "rgba(255,255,255,0.15)",
+                      backdropFilter: "blur(10px)",
+                      border: "1px solid rgba(255,255,255,0.25)",
+                    }}
                   >
-                    {streakWeeks}주 연속 달성
-                  </span>
+                    <span className="text-[13px] leading-none">
+                      {Array.from({ length: Math.min(weeklyCount, 7) }, (_, i) => (
+                        <span key={i}>🔥</span>
+                      ))}
+                    </span>
+                    <span
+                      className="text-[12px] font-semibold tracking-[0.03em]"
+                      style={{ color: "rgba(255,255,255,0.95)" }}
+                    >
+                      이번 주 {weeklyCount}회
+                    </span>
+                  </div>
+
+                  {streakWeeks !== null && streakWeeks >= 2 && (
+                    <div
+                      className="flex items-center gap-[5px] px-[11px] py-[5px] rounded-full"
+                      style={{
+                        background:
+                          "linear-gradient(135deg, rgba(251,146,60,0.85) 0%, rgba(239,68,68,0.75) 100%)",
+                        backdropFilter: "blur(10px)",
+                        border: "1px solid rgba(255,200,100,0.35)",
+                      }}
+                    >
+                      <span className="text-[13px] leading-none">⚡</span>
+                      <span
+                        className="text-[12px] font-bold tracking-[0.02em]"
+                        style={{ color: "rgba(255,255,255,1)" }}
+                      >
+                        {streakWeeks}주 연속 달성
+                      </span>
+                    </div>
+                  )}
                 </div>
               )}
+
+              <div
+                className="mb-[12px]"
+                style={{ height: "1px", background: "rgba(255,255,255,0.2)" }}
+              />
+
+              <h1
+                className="font-bold leading-[1.15] mb-[10px]"
+                style={{
+                  fontSize: "38px",
+                  color: "rgba(255,255,255,0.95)",
+                  textShadow: "0 2px 12px rgba(0,0,0,0.4)",
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {post.title}
+              </h1>
+
+              <p
+                className="text-[14px] font-medium tracking-[0.06em]"
+                style={{ color: "rgba(255,255,255,0.55)" }}
+              >
+                {post.category} · {post.authorCategorySeq}번째 이야기
+              </p>
             </div>
-          )}
-
-          {/* 구분선 */}
-          <div
-            className="mb-[12px]"
-            style={{ height: "1px", background: "rgba(255,255,255,0.2)" }}
+          </>
+        ) : (
+          <PaperTitleCover
+            backgroundColor={post.backgroundColor}
+            dateLabel={format(date, "yyyy · MM · dd")}
+            metaLabel={`${post.category} · ${post.authorCategorySeq}번째 이야기`}
+            weeklyCount={weeklyCount}
+            streakWeeks={streakWeeks}
+            title={
+              <h1
+                className="font-bold leading-[1.15] text-[#4A312B]"
+                style={{
+                  fontSize: "38px",
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {post.title}
+              </h1>
+            }
           />
-
-          {/* 제목 */}
-          <h1
-            className="font-bold leading-[1.15] mb-[10px]"
-            style={{
-              fontSize: "38px",
-              color: "rgba(255,255,255,0.95)",
-              textShadow: "0 2px 12px rgba(0,0,0,0.4)",
-              letterSpacing: "-0.01em",
-            }}
-          >
-            {post.title}
-          </h1>
-
-          {/* 서브텍스트 */}
-          <p
-            className="text-[14px] font-medium tracking-[0.06em]"
-            style={{ color: "rgba(255,255,255,0.55)" }}
-          >
-            {post.category} · {post.authorCategorySeq}번째 이야기
-          </p>
-        </div>
+        )}
       </div>
     </div>
   );
@@ -160,25 +189,27 @@ export function ContentPage({
           transformOrigin: "top left",
           ...getPostPageSurface(backgroundColor),
         }}
-        className={`relative overflow-hidden aspect-square w-[430px] h-[430px] py-[95px] px-[20px] ${tone.shellTextClassName}`}
+        className={`${CONTENT_CARD_SHELL_CLASS} ${tone.shellTextClassName}`}
       >
         <div
-          className="absolute left-[20px] right-[20px] top-[78px] h-px"
+          className={CONTENT_CARD_DIVIDER_CLASS}
           style={{ background: tone.accentLineColor }}
         />
         <div
           className="absolute w-[160px] h-[160px] rounded-full blur-[42px] -top-[48px] -left-[20px]"
           style={{ background: tone.ornamentColor }}
         />
-        <div className="relative z-10">
-          {page.question && (
-            <h2
-              className={`font-semibold text-[32px] mb-[24px] leading-[50px] ${tone.subtitleClassName}`}
-            >
+        {page.question && (
+          <div className={CONTENT_CARD_TITLE_WRAP_CLASS}>
+            <h2 className={`${CONTENT_CARD_TITLE_CLASS} ${tone.subtitleClassName}`}>
               {page.question}
             </h2>
-          )}
-          <div className={`whitespace-pre-wrap ${tone.contentClassName}`}>
+          </div>
+        )}
+        <div className={CONTENT_CARD_BODY_WRAP_CLASS}>
+          <div
+            className={`${CONTENT_CARD_BODY_CLASS} whitespace-pre-wrap ${tone.contentClassName}`}
+          >
             {page.content}
           </div>
         </div>

--- a/features/post/PaperTitleCover.tsx
+++ b/features/post/PaperTitleCover.tsx
@@ -1,0 +1,102 @@
+import { getPostPageTone } from "@/lib/postPageTheme";
+
+type Props = {
+  backgroundColor?: string | null;
+  title: React.ReactNode;
+  dateLabel?: string;
+  metaLabel?: string;
+  weeklyCount?: number | null;
+  streakWeeks?: number | null;
+};
+
+export default function PaperTitleCover({
+  backgroundColor,
+  title,
+  dateLabel,
+  metaLabel,
+  weeklyCount,
+  streakWeeks,
+}: Props) {
+  const tone = getPostPageTone(backgroundColor);
+  const paperCoverSurface = {
+    backgroundColor: "#F6EEE3",
+    backgroundImage:
+      "radial-gradient(circle at 18% 16%, rgba(255,255,255,0.68) 0%, rgba(255,255,255,0) 32%), radial-gradient(circle at 84% 84%, rgba(233, 205, 178, 0.28) 0%, rgba(233,205,178,0) 30%), linear-gradient(160deg, #FBF6F0 0%, #F6EEE3 58%, #EEDDCC 100%)",
+  };
+
+  return (
+    <div
+      style={paperCoverSurface}
+      className={`relative aspect-square w-[390px] h-[390px] overflow-hidden ${tone.shellTextClassName}`}
+    >
+      <div
+        className="absolute -left-[30px] top-[18px] h-[130px] w-[130px] rounded-full blur-[42px]"
+        style={{ background: "rgba(244, 223, 201, 0.38)" }}
+      />
+      <div
+        className="absolute bottom-[30px] right-[6px] h-[150px] w-[150px] rounded-full blur-[52px]"
+        style={{ background: "rgba(234, 202, 172, 0.32)", opacity: 0.9 }}
+      />
+
+      <div className="absolute inset-x-[20px] top-[34px] z-10">
+        <div className="min-h-[54px]">{title}</div>
+      </div>
+
+      <div
+        className="absolute left-[20px] right-[20px] top-[94px] h-px"
+        style={{ background: "rgba(149, 118, 95, 0.13)" }}
+      />
+
+      {(weeklyCount && weeklyCount > 0) || (streakWeeks && streakWeeks >= 2) ? (
+        <div className="absolute bottom-[72px] left-[20px] right-[20px] z-10 flex flex-wrap gap-[8px]">
+          {weeklyCount && weeklyCount > 0 ? (
+            <div
+              className="flex items-center gap-[6px] rounded-full px-[11px] py-[5px]"
+              style={{
+                background: "rgba(255,255,255,0.45)",
+                border: "1px solid rgba(120,112,104,0.12)",
+                backdropFilter: "blur(10px)",
+              }}
+            >
+              <span className="text-[13px] leading-none">
+                {Array.from({ length: Math.min(weeklyCount, 7) }, (_, i) => (
+                  <span key={i}>🔥</span>
+                ))}
+              </span>
+              <span className="text-[12px] font-semibold text-[#6A625D]">
+                이번 주 {weeklyCount}회
+              </span>
+            </div>
+          ) : null}
+
+          {streakWeeks && streakWeeks >= 2 ? (
+            <div
+              className="flex items-center gap-[5px] rounded-full px-[11px] py-[5px]"
+              style={{
+                background: "rgba(255,255,255,0.55)",
+                border: "1px solid rgba(120,112,104,0.12)",
+                backdropFilter: "blur(10px)",
+              }}
+            >
+              <span className="text-[13px] leading-none">⚡</span>
+              <span className="text-[12px] font-bold text-[#6A625D]">
+                {streakWeeks}주 연속 달성
+              </span>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {(dateLabel || metaLabel) && (
+        <div className="absolute bottom-[22px] left-[20px] right-[20px] z-10 flex items-end justify-between gap-4">
+          <span className="text-[12px] font-medium tracking-[0.1em] text-[#8E837A]">
+            {dateLabel}
+          </span>
+          <span className="text-right text-[13px] font-medium text-[#8E837A]">
+            {metaLabel}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/post/contentCardLayout.ts
+++ b/features/post/contentCardLayout.ts
@@ -1,0 +1,16 @@
+export const CONTENT_CARD_SHELL_CLASS =
+  "relative overflow-hidden aspect-square w-[430px] h-[430px] px-[20px] pt-[92px] pb-[30px]";
+
+export const CONTENT_CARD_DIVIDER_CLASS =
+  "absolute left-[20px] right-[20px] top-[70px] h-px";
+
+export const CONTENT_CARD_TITLE_WRAP_CLASS =
+  "absolute left-[20px] right-[20px] top-[20px] z-10";
+
+export const CONTENT_CARD_TITLE_CLASS =
+  "w-full overflow-hidden text-ellipsis whitespace-nowrap bg-transparent text-[24px] leading-[34px] font-medium tracking-[-0.01em]";
+
+export const CONTENT_CARD_BODY_WRAP_CLASS = "relative z-10 h-full";
+
+export const CONTENT_CARD_BODY_CLASS =
+  "w-full bg-transparent text-[15px] leading-[24px] font-[inherit]";

--- a/features/post/create/CreatePostPage.tsx
+++ b/features/post/create/CreatePostPage.tsx
@@ -17,6 +17,7 @@ export default function CreatePostPage(/*{
 }: {
   categoryCounts: CategoryCount[];
 }*/) {
+  const createPageBackgroundClassName = "bg-[#F7F7F5]";
   const router = useRouter();
   const currentStep = useCreatePostStepStore.use.currentStep();
   const resetStep = useCreatePostStepStore.use.resetStep();
@@ -61,6 +62,7 @@ export default function CreatePostPage(/*{
   return (
     <>
       <Modal
+        className={createPageBackgroundClassName}
         onClose={() => setIsCloseModalOpen(true)}
         title={
           typeof title === "string" ? (

--- a/features/post/create/MobileCreatePostPage.tsx
+++ b/features/post/create/MobileCreatePostPage.tsx
@@ -13,6 +13,7 @@ import MobileHeader from "@/components/MobileHeader";
 import { usePrepareDraftPostStats } from "./usePrepareDraftPostStats";
 
 export default function MobileCreatePostPage() {
+  const createPageBackgroundClassName = "bg-[#F7F7F5]";
   const router = useRouter();
   const currentStep = useCreatePostStepStore.use.currentStep();
   const handlePrevStep = useCreatePostStepStore.use.handlePrevStep();
@@ -61,16 +62,22 @@ export default function MobileCreatePostPage() {
       content = null;
   }
   return (
-    <div className="flex-1 flex flex-col h-full">
+    <div className={`flex-1 flex flex-col h-full ${createPageBackgroundClassName}`}>
       {currentStep > 0 ? (
         <div className="flex-shrink-0">
-          <MobileHeader onClick={handlePrevStep}>
+          <MobileHeader
+            className={createPageBackgroundClassName}
+            onClick={handlePrevStep}
+          >
             {headerTitle ?? null}
           </MobileHeader>
         </div>
       ) : (
         <div className="flex-shrink-0">
-          <MobileHeader onClick={router.back}>
+          <MobileHeader
+            className={createPageBackgroundClassName}
+            onClick={router.back}
+          >
             {headerTitle ?? null}
           </MobileHeader>
         </div>

--- a/features/post/create/Slides.tsx
+++ b/features/post/create/Slides.tsx
@@ -8,6 +8,14 @@ import "swiper/css/pagination";
 import "swiper/css/navigation";
 import { useDraftPostStore } from "@/store/CreatePostStore";
 import { getPostPageSurface, getPostPageTone } from "@/lib/postPageTheme";
+import {
+  CONTENT_CARD_BODY_CLASS,
+  CONTENT_CARD_BODY_WRAP_CLASS,
+  CONTENT_CARD_DIVIDER_CLASS,
+  CONTENT_CARD_SHELL_CLASS,
+  CONTENT_CARD_TITLE_CLASS,
+  CONTENT_CARD_TITLE_WRAP_CLASS,
+} from "@/features/post/contentCardLayout";
 
 type Props = {
   currentPage: number;
@@ -17,7 +25,7 @@ type Props = {
 export default function Slides({ currentPage, setCurrentPage }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState<number | null>(null);
-  const size = window.innerWidth < 640 ? (containerWidth ?? 0) : 456;
+  const size = containerWidth ? Math.min(containerWidth, 456) : 456;
 
   const draft = useDraftPostStore.use.post();
   const setPost = useDraftPostStore.use.setPost();
@@ -140,18 +148,18 @@ export default function Slides({ currentPage, setCurrentPage }: Props) {
                       transformOrigin: "top left",
                       ...getPostPageSurface(draft.backgroundColor),
                     }}
-                    className={`relative overflow-hidden aspect-square w-[430px] h-[430px] py-[95px] px-[20px] ${tone.shellTextClassName}`}
+                    className={`${CONTENT_CARD_SHELL_CLASS} ${tone.shellTextClassName}`}
                   >
                     <div
-                      className="absolute left-[20px] right-[20px] top-[78px] h-px"
+                      className={CONTENT_CARD_DIVIDER_CLASS}
                       style={{ background: tone.accentLineColor }}
                     />
                     <div
                       className="absolute w-[160px] h-[160px] rounded-full blur-[42px] -top-[48px] -left-[20px]"
                       style={{ background: tone.ornamentColor }}
                     />
-                    <div className="relative z-10">
-                      {page.subtitle !== undefined && (
+                    {page.subtitle !== undefined && (
+                      <div className={CONTENT_CARD_TITLE_WRAP_CLASS}>
                         <input
                           maxLength={14}
                           onChange={(e) => {
@@ -164,13 +172,15 @@ export default function Slides({ currentPage, setCurrentPage }: Props) {
                             }));
                           }}
                           value={page.subtitle}
-                          className={`w-full font-semibold text-[32px] mb-[24px] leading-[50px] bg-transparent ${tone.subtitleClassName}`}
+                          className={`${CONTENT_CARD_TITLE_CLASS} outline-none ${tone.subtitleClassName}`}
                         />
-                      )}
+                      </div>
+                    )}
 
+                    <div className={CONTENT_CARD_BODY_WRAP_CLASS}>
                       <textarea
                         style={{ maxHeight: maxHeight }}
-                        className={`w-full text-[16px] font-[inherit] ${tone.contentClassName} bg-transparent resize-none outline-none overflow-hidden placeholder:text-current placeholder:opacity-55`}
+                        className={`${CONTENT_CARD_BODY_CLASS} ${tone.contentClassName} resize-none outline-none overflow-hidden placeholder:text-current placeholder:opacity-55`}
                         value={page.content ?? ""}
                         onChange={(e) => {
                           if (e.target.scrollHeight <= maxHeight) {

--- a/features/post/create/TitleEditor.tsx
+++ b/features/post/create/TitleEditor.tsx
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { DraftPost } from "@/types/Post";
 import { getDefaultPostTitle } from "@/lib/postDefaults";
 import { buildUserPath } from "@/lib/nickname";
+import PaperTitleCover from "@/features/post/PaperTitleCover";
 
 export default function TitleEditor() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -31,7 +32,8 @@ export default function TitleEditor() {
 
   const setPost = useDraftPostStore.use.setPost();
   const [isLoading, setIsLoading] = useState(false);
-  const size = window.innerWidth < 640 ? (containerWidth ?? 0) : 480;
+  const size = containerWidth ? Math.min(containerWidth, 480) : 480;
+  const hasPhoto = Boolean(draft.photoUrls?.[0]);
 
   useLayoutEffect(() => {
     if (containerRef.current) {
@@ -83,134 +85,151 @@ export default function TitleEditor() {
           }}
           className="aspect-square w-[390px] h-[390px] relative overflow-hidden"
         >
-          <PostImg url={draft.photoUrls?.[0] || null} filtered />
+          {hasPhoto ? (
+            <>
+              <PostImg url={draft.photoUrls?.[0] || null} filtered />
 
-          {/* 그라디언트 오버레이 */}
-          <div
-            className="absolute inset-0"
-            style={{
-              background:
-                "linear-gradient(to bottom, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0) 35%, rgba(0,0,0,0.18) 65%, rgba(0,0,0,0.45) 100%)",
-            }}
-          />
+              <div
+                className="absolute inset-0"
+                style={{
+                  background:
+                    "linear-gradient(to bottom, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0) 35%, rgba(0,0,0,0.18) 65%, rgba(0,0,0,0.45) 100%)",
+                }}
+              />
 
-          {/* 상단: 날짜 + 카테고리 태그 */}
-          <div className="absolute top-[22px] left-[22px] right-[22px] flex items-center justify-between">
-            <span
-              className="text-[13px] font-medium tracking-[0.12em] uppercase"
-              style={{ color: "rgba(255,255,255,0.75)" }}
-            >
-              {format(new Date(), "yyyy · MM · dd")}
-            </span>
-            <span
-              className="text-[11px] font-semibold tracking-[0.08em] px-[10px] py-[4px] rounded-full border"
-              style={{
-                color: "rgba(255,255,255,0.85)",
-                borderColor: "rgba(255,255,255,0.3)",
-                background: "rgba(255,255,255,0.12)",
-                backdropFilter: "blur(6px)",
-              }}
-            >
-              {draft.category}
-            </span>
-          </div>
+              <div className="absolute top-[22px] left-[22px] right-[22px] flex items-center justify-between">
+                <span
+                  className="text-[13px] font-medium tracking-[0.12em] uppercase"
+                  style={{ color: "rgba(255,255,255,0.75)" }}
+                >
+                  {format(new Date(), "yyyy · MM · dd")}
+                </span>
+                <span
+                  className="text-[11px] font-semibold tracking-[0.08em] px-[10px] py-[4px] rounded-full border"
+                  style={{
+                    color: "rgba(255,255,255,0.85)",
+                    borderColor: "rgba(255,255,255,0.3)",
+                    background: "rgba(255,255,255,0.12)",
+                    backdropFilter: "blur(6px)",
+                  }}
+                >
+                  {draft.category}
+                </span>
+              </div>
 
-          {/* 상단 구분선 */}
-          <div
-            className="absolute left-[22px] right-[22px]"
-            style={{
-              top: "56px",
-              height: "1px",
-              background: "rgba(255,255,255,0.18)",
-            }}
-          />
+              <div
+                className="absolute left-[22px] right-[22px]"
+                style={{
+                  top: "56px",
+                  height: "1px",
+                  background: "rgba(255,255,255,0.18)",
+                }}
+              />
 
-          {/* 하단 콘텐츠 */}
-          <div className="absolute bottom-[22px] left-[22px] right-[22px]">
-            {/* 통계 배지 */}
-            {draft.weeklyWorkoutCount !== undefined &&
-              draft.weeklyWorkoutCount > 0 && (
-                <div className="flex items-center gap-[8px] mb-[14px] flex-wrap">
-                  <div
-                    className="flex items-center gap-[6px] px-[11px] py-[5px] rounded-full"
-                    style={{
-                      background: "rgba(255,255,255,0.15)",
-                      backdropFilter: "blur(10px)",
-                      border: "1px solid rgba(255,255,255,0.25)",
-                    }}
-                  >
-                    <span className="text-[13px] leading-none">
-                      {Array.from(
-                        { length: Math.min(draft.weeklyWorkoutCount, 7) },
-                        (_, i) => (
-                          <span key={i}>🔥</span>
-                        ),
-                      )}
-                    </span>
-                    <span
-                      className="text-[12px] font-semibold tracking-[0.03em]"
-                      style={{ color: "rgba(255,255,255,0.95)" }}
-                    >
-                      이번 주 {draft.weeklyWorkoutCount}회
-                    </span>
-                  </div>
-
-                  {draft.continuousGoalWeeks !== undefined &&
-                    draft.continuousGoalWeeks >= 2 && (
+              <div className="absolute bottom-[22px] left-[22px] right-[22px]">
+                {draft.weeklyWorkoutCount !== undefined &&
+                  draft.weeklyWorkoutCount > 0 && (
+                    <div className="flex items-center gap-[8px] mb-[14px] flex-wrap">
                       <div
-                        className="flex items-center gap-[5px] px-[11px] py-[5px] rounded-full"
+                        className="flex items-center gap-[6px] px-[11px] py-[5px] rounded-full"
                         style={{
-                          background:
-                            "linear-gradient(135deg, rgba(251,146,60,0.85) 0%, rgba(239,68,68,0.75) 100%)",
+                          background: "rgba(255,255,255,0.15)",
                           backdropFilter: "blur(10px)",
-                          border: "1px solid rgba(255,200,100,0.35)",
+                          border: "1px solid rgba(255,255,255,0.25)",
                         }}
                       >
-                        <span className="text-[13px] leading-none">⚡</span>
+                        <span className="text-[13px] leading-none">
+                          {Array.from(
+                            { length: Math.min(draft.weeklyWorkoutCount, 7) },
+                            (_, i) => (
+                              <span key={i}>🔥</span>
+                            ),
+                          )}
+                        </span>
                         <span
-                          className="text-[12px] font-bold tracking-[0.02em]"
-                          style={{ color: "rgba(255,255,255,1)" }}
+                          className="text-[12px] font-semibold tracking-[0.03em]"
+                          style={{ color: "rgba(255,255,255,0.95)" }}
                         >
-                          {draft.continuousGoalWeeks}주 연속 달성
+                          이번 주 {draft.weeklyWorkoutCount}회
                         </span>
                       </div>
-                    )}
-                </div>
-              )}
 
-            {/* 구분선 */}
-            <div
-              className="mb-[12px]"
-              style={{ height: "1px", background: "rgba(255,255,255,0.2)" }}
+                      {draft.continuousGoalWeeks !== undefined &&
+                        draft.continuousGoalWeeks >= 2 && (
+                          <div
+                            className="flex items-center gap-[5px] px-[11px] py-[5px] rounded-full"
+                            style={{
+                              background:
+                                "linear-gradient(135deg, rgba(251,146,60,0.85) 0%, rgba(239,68,68,0.75) 100%)",
+                              backdropFilter: "blur(10px)",
+                              border: "1px solid rgba(255,200,100,0.35)",
+                            }}
+                          >
+                            <span className="text-[13px] leading-none">⚡</span>
+                            <span
+                              className="text-[12px] font-bold tracking-[0.02em]"
+                              style={{ color: "rgba(255,255,255,1)" }}
+                            >
+                              {draft.continuousGoalWeeks}주 연속 달성
+                            </span>
+                          </div>
+                        )}
+                    </div>
+                  )}
+
+                <div
+                  className="mb-[12px]"
+                  style={{ height: "1px", background: "rgba(255,255,255,0.2)" }}
+                />
+
+                <input
+                  maxLength={18}
+                  className="w-full font-bold leading-[1.15] outline-none bg-transparent mb-[10px]"
+                  style={{
+                    fontSize: "38px",
+                    color: "rgba(255,255,255,0.95)",
+                    textShadow: "0 2px 12px rgba(0,0,0,0.4)",
+                    letterSpacing: "-0.01em",
+                  }}
+                  type="text"
+                  placeholder={getDefaultPostTitle(draft.category)}
+                  autoFocus
+                  value={draft.title ?? ""}
+                  onChange={(e) => {
+                    setPost({ title: e.target.value });
+                  }}
+                />
+
+                <p
+                  className="text-[14px] font-medium tracking-[0.06em]"
+                  style={{ color: "rgba(255,255,255,0.55)" }}
+                >
+                  {draft.category} · {(draft.categoryCount ?? 0) + 1}번째 이야기
+                </p>
+              </div>
+            </>
+          ) : (
+            <PaperTitleCover
+              backgroundColor={draft.backgroundColor}
+              dateLabel={format(new Date(), "yyyy · MM · dd")}
+              metaLabel={`${draft.category} · ${(draft.categoryCount ?? 0) + 1}번째 이야기`}
+              weeklyCount={draft.weeklyWorkoutCount}
+              streakWeeks={draft.continuousGoalWeeks}
+              title={
+                <input
+                  maxLength={18}
+                  className="w-full bg-transparent text-[38px] font-bold leading-[1.15] tracking-[-0.01em] text-[#4A312B] outline-none placeholder:text-[#8E837A]"
+                  type="text"
+                  placeholder={getDefaultPostTitle(draft.category)}
+                  autoFocus
+                  value={draft.title ?? ""}
+                  onChange={(e) => {
+                    setPost({ title: e.target.value });
+                  }}
+                />
+              }
             />
-
-            {/* 제목 */}
-            <input
-              maxLength={18}
-              className="w-full font-bold leading-[1.15] outline-none bg-transparent mb-[10px]"
-              style={{
-                fontSize: "38px",
-                color: "rgba(255,255,255,0.95)",
-                textShadow: "0 2px 12px rgba(0,0,0,0.4)",
-                letterSpacing: "-0.01em",
-              }}
-              type="text"
-              placeholder={getDefaultPostTitle(draft.category)}
-              autoFocus
-              value={draft.title ?? ""}
-              onChange={(e) => {
-                setPost({ title: e.target.value });
-              }}
-            />
-
-            {/* 서브텍스트 */}
-            <p
-              className="text-[14px] font-medium tracking-[0.06em]"
-              style={{ color: "rgba(255,255,255,0.55)" }}
-            >
-              {draft.category} · {(draft.categoryCount ?? 0) + 1}번째 이야기
-            </p>
-          </div>
+          )}
         </div>
       </div>
       <div className="w-full mt-5">

--- a/lib/postDefaults.ts
+++ b/lib/postDefaults.ts
@@ -1,5 +1,5 @@
 import type { Category } from "@/types/Categories";
-import type { DraftPost, PostPage } from "@/types/Post";
+import type { BackgroundColor, DraftPost, PostPage } from "@/types/Post";
 
 const DEFAULT_CATEGORY: Category = "오늘 은혜";
 
@@ -10,13 +10,23 @@ const defaultTitleByCategory: Record<Category, string> = {
 };
 
 const defaultSubtitlesByCategory: Record<Category, string[]> = {
-  "오늘 은혜": ["오늘의 은혜", "감사의 기도"],
+  "오늘 은혜": ["오늘의 은혜"],
   "성경 일독": ["오늘의 성경 말씀", "말씀 속 느낀 점"],
   "교회 앨범": ["오늘 교회 속 이야기"],
 };
 
+const defaultBackgroundByCategory: Record<Category, BackgroundColor> = {
+  "오늘 은혜": "#F7F7F5",
+  "성경 일독": "#F0E8E0",
+  "교회 앨범": "#F0E8E0",
+};
+
 export function getDefaultPostTitle(category?: Category) {
   return defaultTitleByCategory[category ?? DEFAULT_CATEGORY];
+}
+
+export function getDefaultPostBackground(category?: Category) {
+  return defaultBackgroundByCategory[category ?? DEFAULT_CATEGORY];
 }
 
 export function createDefaultPostPages(category?: Category): PostPage[] {
@@ -31,7 +41,7 @@ export function createDefaultPostPages(category?: Category): PostPage[] {
 
 export function createInitialDraftPost(category?: Category): DraftPost {
   return {
-    backgroundColor: "#F0E8E0",
+    backgroundColor: getDefaultPostBackground(category),
     pages: createDefaultPostPages(category),
   };
 }

--- a/lib/postPageTheme.ts
+++ b/lib/postPageTheme.ts
@@ -1,13 +1,18 @@
 import type { CSSProperties } from "react";
 
 export const DEFAULT_POST_PAGE_BACKGROUND = "#F0E8E0" as const;
+export const TODAY_GRACE_POST_PAGE_BACKGROUND = "#F7F7F5" as const;
 
 function getEffectivePostBackground(backgroundColor?: string | null) {
-  return backgroundColor ?? DEFAULT_POST_PAGE_BACKGROUND;
+  return backgroundColor ?? TODAY_GRACE_POST_PAGE_BACKGROUND;
 }
 
 export function isWarmPaperTheme(backgroundColor?: string | null) {
-  return getEffectivePostBackground(backgroundColor) === DEFAULT_POST_PAGE_BACKGROUND;
+  const effectiveBackground = getEffectivePostBackground(backgroundColor);
+  return (
+    effectiveBackground === DEFAULT_POST_PAGE_BACKGROUND ||
+    effectiveBackground === TODAY_GRACE_POST_PAGE_BACKGROUND
+  );
 }
 
 export function getPostPageSurface(
@@ -16,6 +21,14 @@ export function getPostPageSurface(
   const effectiveBackground = getEffectivePostBackground(backgroundColor);
 
   if (isWarmPaperTheme(effectiveBackground)) {
+    if (effectiveBackground === TODAY_GRACE_POST_PAGE_BACKGROUND) {
+      return {
+        backgroundColor: TODAY_GRACE_POST_PAGE_BACKGROUND,
+        backgroundImage:
+          "radial-gradient(circle at 18% 18%, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0) 34%), radial-gradient(circle at 82% 84%, rgba(212,212,206,0.18) 0%, rgba(212,212,206,0) 28%), linear-gradient(160deg, #FCFCFB 0%, #F7F7F5 58%, #EFEFEA 100%)",
+      };
+    }
+
     return {
       backgroundColor: DEFAULT_POST_PAGE_BACKGROUND,
       backgroundImage:
@@ -30,6 +43,16 @@ export function getPostPageSurface(
 
 export function getPostPageTone(backgroundColor?: string | null) {
   const effectiveBackground = getEffectivePostBackground(backgroundColor);
+
+  if (effectiveBackground === TODAY_GRACE_POST_PAGE_BACKGROUND) {
+    return {
+      shellTextClassName: "text-[#4A312B]",
+      subtitleClassName: "text-[#4A312B]",
+      contentClassName: "text-[#6A625D]",
+      accentLineColor: "rgba(120, 112, 104, 0.14)",
+      ornamentColor: "rgba(214, 214, 209, 0.24)",
+    };
+  }
 
   if (isWarmPaperTheme(effectiveBackground)) {
     return {

--- a/types/Post.ts
+++ b/types/Post.ts
@@ -34,6 +34,7 @@ export type CategoryCharCount = {
 
 export type BackgroundColor =
   | "#f9f9f9"
+  | "#F7F7F5"
   | "#F0E8E0"
   | "#000000"
   | "#412A2A"


### PR DESCRIPTION
## 작업 내용
- 오늘 은혜 작성 화면의 제목/본문 간격과 타이포를 소제목 톤으로 정리
- 작성 화면과 게시물 업로드/미리보기 카드 레이아웃을 공통 스타일로 맞춤
- 오늘 은혜 기본 배경색과 기본 페이지 구성을 정리
- 사진 미선택 시 사용하는 기본 표지를 종이 톤 디자인으로 교체

## 커밋 구성
- `e534fb5` style: refine today grace defaults and create surfaces
- `7947d3e` style: unify post editor and preview card layouts

## 확인 포인트
- 오늘 은혜 작성 화면에서 제목이 더 작고 정돈된 소제목처럼 보이는지
- 본문 입력 시작 위치가 이전보다 위로 올라왔는지
- 업로드/미리보기 시점 카드와 작성 화면의 스타일이 일관적인지
- 사진이 없을 때 기본 표지가 새 디자인으로 노출되는지